### PR TITLE
Wait for sync header

### DIFF
--- a/python/tracer/__init__.py
+++ b/python/tracer/__init__.py
@@ -122,7 +122,7 @@ class TracerSerial(object):
         # Wait for sync-header, ignore any trash before.
         header_ok = False
         start_idx = 0
-        while b >= 0 and read_idx < to_read:
+        while read_idx < to_read:
             buff += bytearray(self.port.read(1))
             read_idx += 1
             if read_idx < len(self.sync_header):

--- a/python/tracer/__init__.py
+++ b/python/tracer/__init__.py
@@ -24,6 +24,7 @@ class Result(object):
         """Convert a list of two bytes into a floating point value."""
         # convert two bytes to a float value
         return ((two_bytes[1] << 8) | two_bytes[0]) / 100.0
+
     def __str__(self):
         return "%s{%s}" % (self.__class__.__name__, ", ".join(map(lambda a: "%s: %s" % (a, getattr(self, a)), self.props)))
 
@@ -32,8 +33,8 @@ class QueryResult(Result):
     props=['batt_voltage', 'pv_voltage', 'load_amps', 'batt_overdischarge_voltage', 'batt_full_voltage', 'load_on', 'load_overload', 'load_short', 'batt_overload', 'batt_overdischarge', 'batt_full', 'batt_charging', 'batt_temp', 'charge_current']
     def decode(self, data):
         """Decodes the query result, storing results as fields"""
-	if len(data) < 23:
-	    print "Not enough data. Need 23 bytes, got %d" % len(data)
+        if len(data) < 23:
+          print "Not enough data. Need 23 bytes, got %d" % len(data)
         self.batt_voltage = self.to_float(data[0:2])
         self.pv_voltage = self.to_float(data[2:4])
         # [4:2] reserved; always 0
@@ -105,7 +106,7 @@ class TracerSerial(object):
             raise Exception("Invalid length. Expecting %d, got %d" % (data[8] + 12, len(data)))
         if not self.tracer.verify_crc(data[6:]):
             print "invalid crc"
-	    #raise Exception("Invalid CRC")
+              #raise Exception("Invalid CRC")
         return self.tracer.get_result(data[6:])
 
     def send_command(self, command):
@@ -122,8 +123,8 @@ class TracerSerial(object):
         b = 0
         while b >= 0 and read_idx < (to_read + 12):
             b = bytearray(self.port.read(1))
-	    if not b >= 0:
-		break
+            if not b >= 0:
+              break
             buff += b
             if read_idx < len(self.sync_header) and b[0] != self.sync_header[read_idx]:
                 raise IOError("Error receiving result: invalid sync header")

--- a/python/tracer/__init__.py
+++ b/python/tracer/__init__.py
@@ -110,6 +110,10 @@ class TracerSerial(object):
         return self.tracer.get_result(data[6:])
 
     def send_command(self, command):
+        # Reset input in case there are some trash in the buffer
+        # that receive result from a QueryCommand would pick up.
+        self.port.reset_input_buffer()
+
         to_send = self.to_bytes(command)
         if len(to_send) != self.port.write(to_send):
             raise IOError("Error sending command: did not send all bytes")

--- a/python/tracer/__init__.py
+++ b/python/tracer/__init__.py
@@ -124,7 +124,7 @@ class TracerSerial(object):
         while b >= 0 and read_idx < (to_read + 12):
             b = bytearray(self.port.read(1))
             if not b >= 0:
-              break
+                break
             buff += b
             if read_idx < len(self.sync_header) and b[0] != self.sync_header[read_idx]:
                 raise IOError("Error receiving result: invalid sync header")


### PR DESCRIPTION
I've been seeing some "invalid sync header" because the port input buffer contained other data before a message. Let receive_result ignore any data before the first sync-header received.

(pull request dependent on tabsp pull-request)